### PR TITLE
refactor: rename testDate to lastTested across the codebase

### DIFF
--- a/docs/legacy-documentation-and-design-decisions.md
+++ b/docs/legacy-documentation-and-design-decisions.md
@@ -203,7 +203,7 @@ User → Dashboard Page → ServiceRepository → MongoDB → Service Documents
 - `statusIsUp` - Endpoint availability
 - `statusIsValid` - ORUK compliance
 - `statusOverall` - Combined health status
-- `testDate` - Last validation timestamp
+- `lastTested` - Last validation timestamp
 
 ### 2. API Validator Tool
 
@@ -335,7 +335,6 @@ interface ServiceDocument {
   statusIsUp: { value: boolean }
   statusIsValid: { value: boolean }
   statusOverall: { value: boolean }
-  testDate: { value: Date | null }
   lastTested: { value: Date | null }
   active: boolean
   createdAt: Date

--- a/src/app/community/directory/_components/ServicesTable/ServicesTable.tsx
+++ b/src/app/community/directory/_components/ServicesTable/ServicesTable.tsx
@@ -19,7 +19,7 @@ const TABLE_HEADERS: TableHeaderConfig[] = [
   { key: 'publisher', label: 'Publisher', sortable: true },
   { key: 'comment', label: 'Description', sortable: false, className: styles.hiddenOnTablet },
   { key: 'developer', label: 'Developer', sortable: true, className: styles.hiddenOnTablet },
-  { key: 'testDate', label: 'Last Tested', sortable: true, className: styles.hiddenOnMobile }
+  { key: 'lastTested', label: 'Last Tested', sortable: true, className: styles.hiddenOnMobile }
 ]
 
 export function ServicesTable({

--- a/src/app/community/directory/_components/ServicesTable/TableComponents.tsx
+++ b/src/app/community/directory/_components/ServicesTable/TableComponents.tsx
@@ -18,7 +18,7 @@ export function MobileSortSelector({
     { value: 'name', label: 'Name' },
     { value: 'publisher', label: 'Publisher' },
     { value: 'developer', label: 'Developer' },
-    { value: 'testDate', label: 'Last Tested' }
+    { value: 'lastTested', label: 'Last Tested' }
   ]
 
   const directionLabel = currentDirection === 'asc' ? 'A-Z' : 'Z-A'
@@ -90,7 +90,7 @@ export function ServiceCard({ service, index: _index }: ServiceCardProps) {
         {renderField('Name', service.name)}
         {renderField('Publisher', service.publisher)}
         {renderField('Developer', service.developer)}
-        {renderField('Last Tested', service.testDate)}
+        {renderField('Last Tested', service.lastTested)}
         {service.comment && service.comment.value && service.comment.value !== 'N/A' && (
           <div className={styles.cardField}>
             <dt className={styles.cardLabel}>Description:</dt>

--- a/src/app/community/directory/_components/ServicesTable/hooks.ts
+++ b/src/app/community/directory/_components/ServicesTable/hooks.ts
@@ -13,7 +13,7 @@ export function useSortedData(data: ServiceData[], sortConfig: SortConfig | null
 
       // Handle date sorting
       if (
-        sortConfig.field === 'testDate' &&
+        sortConfig.field === 'lastTested' &&
         typeof aValue === 'string' &&
         typeof bValue === 'string'
       ) {

--- a/src/app/community/directory/_components/ServicesTable/types.ts
+++ b/src/app/community/directory/_components/ServicesTable/types.ts
@@ -3,7 +3,7 @@ export interface ServiceData {
   publisher: { value: string; url?: string }
   comment: { value: string }
   developer: { value: string; url?: string }
-  testDate: { value: Date | undefined; url?: string }
+  lastTested: { value: Date | undefined; url?: string }
 }
 
 export type SortField = keyof ServiceData

--- a/src/app/community/directory/page.tsx
+++ b/src/app/community/directory/page.tsx
@@ -80,7 +80,7 @@ export default async function Page(props: PageProps) {
       publisher: { value: getPublisher(), url: getPublisherUrl() },
       comment: { value: getDescription() },
       developer: { value: getDeveloper(), url: getDeveloperUrl() },
-      testDate: { value: s.testDate || s.lastTested, url: `/developers/dashboard/${s.id}` }
+      lastTested: { value: s.lastTested, url: `/developers/dashboard/${s.id}` }
     }
   })
 

--- a/src/app/developers/dashboard/[id]/_components/DashboardDetails.tsx
+++ b/src/app/developers/dashboard/[id]/_components/DashboardDetails.tsx
@@ -17,7 +17,7 @@ interface TestResult {
   developer: { value: string; url: string }
   service: { value: string; url: string }
   isValid: boolean
-  testDate: { value: Date | undefined }
+  lastTested: { value: Date | undefined }
   payload: SectionData[]
 }
 
@@ -129,8 +129,8 @@ const Validation = ({ status, result }: ValidationProps) => {
       <div className={styles.field}>
         <span className={styles.label}>Last checked</span>
         <span className={styles.fv}>
-          {result.testDate.value ? (
-            <LocalisedDate value={result.testDate.value} options={fmtOptions} />
+          {result.lastTested.value ? (
+            <LocalisedDate value={result.lastTested.value} options={fmtOptions} />
           ) : (
             <>Not Tested</>
           )}

--- a/src/app/developers/dashboard/[id]/page.tsx
+++ b/src/app/developers/dashboard/[id]/page.tsx
@@ -48,7 +48,7 @@ function transformServiceForDashboard(service: any) {
       developer: { value: developerValue, url: developerUrl },
       service: { value: serviceValue, url: serviceUrl },
       isValid: Boolean(isValid),
-      testDate: { value: service.testDate || service.lastTested },
+      lastTested: { value: service.lastTested },
       payload: [
         {
           label: 'Service Details',

--- a/src/app/developers/dashboard/_components/DashboardTable/DashboardTable.tsx
+++ b/src/app/developers/dashboard/_components/DashboardTable/DashboardTable.tsx
@@ -25,7 +25,7 @@ const TABLE_HEADERS: TableHeaderConfig[] = [
     sortable: true,
     className: styles.hiddenOnTablet
   },
-  { key: 'testDate', label: 'Last Tested', sortable: true, className: styles.hiddenOnMobile }
+  { key: 'lastTested', label: 'Last Tested', sortable: true, className: styles.hiddenOnMobile }
 ]
 
 export function DashboardTable({

--- a/src/app/developers/dashboard/_components/DashboardTable/TableComponents.tsx
+++ b/src/app/developers/dashboard/_components/DashboardTable/TableComponents.tsx
@@ -21,7 +21,7 @@ export function MobileSortSelector({
     { value: 'statusIsUp', label: 'Feed is live' },
     { value: 'statusIsValid', label: 'Feed is valid' },
     { value: 'schemaVersion', label: 'Schema Version' },
-    { value: 'testDate', label: 'Last Tested' }
+    { value: 'lastTested', label: 'Last Tested' }
   ]
 
   const directionLabel = currentDirection === 'asc' ? 'A-Z' : 'Z-A'
@@ -97,7 +97,7 @@ export function ServiceCard({ service, index: _index }: ServiceCardProps) {
         {renderField('Feed is live', service.statusIsUp)}
         {renderField('Feed is valid', service.statusIsValid)}
         {renderField('Schema Version', service.schemaVersion)}
-        {renderField('Last Tested', service.testDate)}
+        {renderField('Last Tested', service.lastTested)}
       </dl>
     </div>
   )

--- a/src/app/developers/dashboard/_components/DashboardTable/hooks.ts
+++ b/src/app/developers/dashboard/_components/DashboardTable/hooks.ts
@@ -13,7 +13,7 @@ export function useSortedData(data: ServiceData[], sortConfig: SortConfig | null
 
       // Handle date sorting
       if (
-        sortConfig.field === 'testDate' &&
+        sortConfig.field === 'lastTested' &&
         typeof aValue === 'string' &&
         typeof bValue === 'string'
       ) {

--- a/src/app/developers/dashboard/_components/DashboardTable/types.ts
+++ b/src/app/developers/dashboard/_components/DashboardTable/types.ts
@@ -4,7 +4,7 @@ export interface ServiceData {
   statusIsUp: { value: boolean; url?: string }
   statusIsValid: { value: boolean; url?: string }
   schemaVersion: { value: string; url?: string }
-  testDate: { value: Date | undefined; url?: string }
+  lastTested: { value: Date | undefined; url?: string }
 }
 
 export type SortField = keyof ServiceData

--- a/src/app/developers/dashboard/page.tsx
+++ b/src/app/developers/dashboard/page.tsx
@@ -33,7 +33,7 @@ export default async function Page(props: PageProps) {
       statusIsUp: { value: s.statusIsUp },
       statusIsValid: { value: s.statusIsValid },
       schemaVersion: { value: String(s.schemaVersion || 'N/A') },
-      testDate: { value: s.testDate || s.lastTested, url: `/developers/dashboard/${s.id}` }
+      lastTested: { value: s.lastTested, url: `/developers/dashboard/${s.id}` }
     }
   })
 

--- a/src/components/Dashboard/generateDummyData.ts
+++ b/src/components/Dashboard/generateDummyData.ts
@@ -16,7 +16,7 @@ interface DataRow {
   statusIsUp: { value: number }
   statusIsValid: { value: number }
   statusOverall: { value: number }
-  testDate: { value: string; url: string }
+  lastTested: { value: string; url: string }
 }
 
 export const generate = ({ numRows, rowsPerPage, failEveryNRows }: GenerateParams) => ({
@@ -90,7 +90,7 @@ export const generateDataRow = (rowNum: number, fail: boolean): DataRow => {
     statusOverall: {
       value: fail ? 0 : 1
     },
-    testDate: {
+    lastTested: {
       value: '2024-08-06T18:' + padRowNum(rowNum) + ':07',
       url: '/developers/dashboard/' + rowNum
     }

--- a/src/components/Dashboard/sharedDefinitions.json
+++ b/src/components/Dashboard/sharedDefinitions.json
@@ -36,7 +36,7 @@
       "label": "Feed passes?",
       "dataType": "oruk:dataType.success"
     },
-    "testDate": {
+    "lastTested": {
       "label": "Last tested",
       "dataType": "oruk:dataType.dateTime"
     }
@@ -49,16 +49,16 @@
         "statusIsUp",
         "statusIsValid",
         "schemaVersion",
-        "testDate"
+        "lastTested"
       ],
-      "sortBy": ["name", "statusOverall", "schemaVersion", "testDate"],
+      "sortBy": ["name", "statusOverall", "schemaVersion", "lastTested"],
       "defaultSortDirection": "ascending",
       "defaultSortBy": "name",
       "showPassingRowsOnly": false
     },
     "directory": {
-      "columns": ["name", "publisher", "comment", "developer", "service", "testDate"],
-      "sortBy": ["name", "publisher", "developer", "testDate"],
+      "columns": ["name", "publisher", "comment", "developer", "service", "lastTested"],
+      "sortBy": ["name", "publisher", "developer", "lastTested"],
       "defaultSortDirection": "ascending",
       "defaultSortBy": "name",
       "showPassingRowsOnly": true

--- a/src/components/DashboardTable/DashboardTable.tsx
+++ b/src/components/DashboardTable/DashboardTable.tsx
@@ -25,7 +25,7 @@ const TABLE_HEADERS: TableHeaderConfig[] = [
     sortable: true,
     className: styles.hiddenOnTablet
   },
-  { key: 'testDate', label: 'Last Tested', sortable: true, className: styles.hiddenOnMobile }
+  { key: 'lastTested', label: 'Last Tested', sortable: true, className: styles.hiddenOnMobile }
 ]
 
 export function DashboardTable({

--- a/src/components/DashboardTable/TableComponents.tsx
+++ b/src/components/DashboardTable/TableComponents.tsx
@@ -21,7 +21,7 @@ export function MobileSortSelector({
     { value: 'statusIsUp', label: 'Feed is live' },
     { value: 'statusIsValid', label: 'Feed is valid' },
     { value: 'schemaVersion', label: 'Schema Version' },
-    { value: 'testDate', label: 'Last Tested' }
+    { value: 'lastTested', label: 'Last Tested' }
   ]
 
   const directionLabel = currentDirection === 'asc' ? 'A-Z' : 'Z-A'
@@ -97,7 +97,7 @@ export function ServiceCard({ service, index: _index }: ServiceCardProps) {
         {renderField('Feed is live', service.statusIsUp)}
         {renderField('Feed is valid', service.statusIsValid)}
         {renderField('Schema Version', service.schemaVersion)}
-        {renderField('Last Tested', service.testDate)}
+        {renderField('Last Tested', service.lastTested)}
       </dl>
     </div>
   )

--- a/src/components/DashboardTable/hooks.ts
+++ b/src/components/DashboardTable/hooks.ts
@@ -13,7 +13,7 @@ export function useSortedData(data: ServiceData[], sortConfig: SortConfig | null
 
       // Handle date sorting
       if (
-        sortConfig.field === 'testDate' &&
+        sortConfig.field === 'lastTested' &&
         typeof aValue === 'string' &&
         typeof bValue === 'string'
       ) {

--- a/src/components/DashboardTable/types.ts
+++ b/src/components/DashboardTable/types.ts
@@ -4,7 +4,7 @@ export interface ServiceData {
   statusIsUp: { value: boolean; url?: string }
   statusIsValid: { value: boolean; url?: string }
   schemaVersion: { value: string; url?: string }
-  testDate: { value: Date | undefined; url?: string }
+  lastTested: { value: Date | undefined; url?: string }
 }
 
 export type SortField = keyof ServiceData

--- a/src/components/PaginatedTable/paginatedExample.json
+++ b/src/components/PaginatedTable/paginatedExample.json
@@ -31,7 +31,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T18:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -68,7 +68,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -104,7 +104,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -140,7 +140,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -176,7 +176,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -212,7 +212,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -248,7 +248,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -284,7 +284,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -320,7 +320,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -356,7 +356,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -392,7 +392,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -428,7 +428,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -464,7 +464,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -500,7 +500,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -536,7 +536,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -572,7 +572,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -608,7 +608,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -644,7 +644,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -680,7 +680,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -716,7 +716,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -752,7 +752,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -788,7 +788,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -824,7 +824,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -860,7 +860,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -896,7 +896,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -932,7 +932,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -968,7 +968,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000002"
       }
@@ -1003,7 +1003,7 @@
       "statusOverall": {
         "value": 0
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T10:00:07",
         "url": "/dashboard/test/000003"
       }
@@ -1047,7 +1047,7 @@
         "label": "Feed passes?",
         "valueType": "oruk:valueType.success"
       },
-      "testDate": {
+      "lastTested": {
         "label": "Last tested",
         "valueType": "oruk:valueType.dateTime"
       }
@@ -1060,7 +1060,7 @@
           "statusIsUp",
           "statusIsValid",
           "schemaVersion",
-          "testDate"
+          "lastTested"
         ],
         "defaultSortBy": [
           {

--- a/src/components/ServicesTable/ServicesTable.tsx
+++ b/src/components/ServicesTable/ServicesTable.tsx
@@ -19,7 +19,7 @@ const TABLE_HEADERS: TableHeaderConfig[] = [
   { key: 'publisher', label: 'Publisher', sortable: true },
   { key: 'comment', label: 'Description', sortable: false, className: styles.hiddenOnTablet },
   { key: 'developer', label: 'Developer', sortable: true, className: styles.hiddenOnTablet },
-  { key: 'testDate', label: 'Last Tested', sortable: true, className: styles.hiddenOnMobile }
+  { key: 'lastTested', label: 'Last Tested', sortable: true, className: styles.hiddenOnMobile }
 ]
 
 export function ServicesTable({

--- a/src/components/ServicesTable/TableComponents.tsx
+++ b/src/components/ServicesTable/TableComponents.tsx
@@ -18,7 +18,7 @@ export function MobileSortSelector({
     { value: 'name', label: 'Name' },
     { value: 'publisher', label: 'Publisher' },
     { value: 'developer', label: 'Developer' },
-    { value: 'testDate', label: 'Last Tested' }
+    { value: 'lastTested', label: 'Last Tested' }
   ]
 
   const directionLabel = currentDirection === 'asc' ? 'A-Z' : 'Z-A'
@@ -90,7 +90,7 @@ export function ServiceCard({ service, index: _index }: ServiceCardProps) {
         {renderField('Name', service.name)}
         {renderField('Publisher', service.publisher)}
         {renderField('Developer', service.developer)}
-        {renderField('Last Tested', service.testDate)}
+        {renderField('Last Tested', service.lastTested)}
         {service.comment && service.comment.value && service.comment.value !== 'N/A' && (
           <div className={styles.cardField}>
             <dt className={styles.cardLabel}>Description:</dt>

--- a/src/components/ServicesTable/hooks.ts
+++ b/src/components/ServicesTable/hooks.ts
@@ -13,7 +13,7 @@ export function useSortedData(data: ServiceData[], sortConfig: SortConfig | null
 
       // Handle date sorting
       if (
-        sortConfig.field === 'testDate' &&
+        sortConfig.field === 'lastTested' &&
         typeof aValue === 'string' &&
         typeof bValue === 'string'
       ) {

--- a/src/components/ServicesTable/types.ts
+++ b/src/components/ServicesTable/types.ts
@@ -3,7 +3,7 @@ export interface ServiceData {
   publisher: { value: string; url?: string }
   comment: { value: string }
   developer: { value: string; url?: string }
-  testDate: { value: Date | undefined; url?: string }
+  lastTested: { value: Date | undefined; url?: string }
 }
 
 export type SortField = keyof ServiceData

--- a/src/components/SortedAndPaginatedTable/_components/PaginatedTable/paginatedExample.json
+++ b/src/components/SortedAndPaginatedTable/_components/PaginatedTable/paginatedExample.json
@@ -31,7 +31,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T18:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -68,7 +68,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -104,7 +104,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -140,7 +140,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -176,7 +176,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -212,7 +212,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -248,7 +248,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -284,7 +284,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -320,7 +320,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -356,7 +356,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -392,7 +392,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -428,7 +428,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -464,7 +464,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -500,7 +500,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -536,7 +536,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -572,7 +572,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -608,7 +608,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -644,7 +644,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -680,7 +680,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -716,7 +716,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -752,7 +752,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -788,7 +788,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -824,7 +824,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -860,7 +860,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -896,7 +896,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -932,7 +932,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000001"
       }
@@ -968,7 +968,7 @@
       "statusOverall": {
         "value": 1
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T12:00:07",
         "url": "/dashboard/test/000002"
       }
@@ -1003,7 +1003,7 @@
       "statusOverall": {
         "value": 0
       },
-      "testDate": {
+      "lastTested": {
         "value": "2024-08-06T10:00:07",
         "url": "/dashboard/test/000003"
       }
@@ -1047,7 +1047,7 @@
         "label": "Feed passes?",
         "valueType": "oruk:valueType.success"
       },
-      "testDate": {
+      "lastTested": {
         "label": "Last tested",
         "valueType": "oruk:valueType.dateTime"
       }
@@ -1060,7 +1060,7 @@
           "statusIsUp",
           "statusIsValid",
           "schemaVersion",
-          "testDate"
+          "lastTested"
         ],
         "defaultSortBy": [
           {

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -14,7 +14,6 @@ export const serviceBaseFieldsSchema = z.object({
   developerUrl: z.url().max(191),
   serviceUrl: z.url().max(191),
   contactEmail: z.email().max(191),
-  testDate: z.date().optional(),
   lastTested: z.date().optional(),
   active: z.boolean().optional().default(false)
 })
@@ -37,7 +36,6 @@ export const insertServiceSchema = z.object({
   statusIsUp: z.object({ value: z.boolean().optional().default(false) }).optional(),
   statusIsValid: z.object({ value: z.boolean().optional().default(false) }).optional(),
   statusOverall: z.object({ value: z.boolean().optional().default(false) }).optional(),
-  testDate: z.object({ value: z.date().nullable().optional() }).optional(),
   lastTested: z.object({ value: z.date().nullable().optional() }).optional(),
   active: z.boolean().optional().default(false),
   createdAt: z.date(),
@@ -70,7 +68,6 @@ export const serviceResponseSchema = z.object({
   statusNote: z.string().optional(),
   statusOverall: z.boolean().optional().default(false),
   createdAt: z.date(),
-  testDate: z.date().optional(),
   lastTested: z.date().optional(),
   updatedAt: z.date(),
   updateLink: z.string(),
@@ -105,7 +102,6 @@ export function toServiceResponse(doc: ServiceDocument): ServiceResponse {
     statusOverall: Boolean(doc.statusOverall?.value),
     createdAt: doc.createdAt,
     updatedAt: doc.updatedAt,
-    testDate: doc.testDate?.value ?? undefined,
     lastTested: doc.lastTested?.value ?? undefined,
     updateLink: `/developers/register/${doc._id.toHexString()}`,
     active: doc.active ?? false,

--- a/src/repositories/service-repository.ts
+++ b/src/repositories/service-repository.ts
@@ -50,7 +50,6 @@ export class ServiceRepository extends BaseRepository<
       statusIsUp: { value: false },
       statusIsValid: { value: false },
       statusOverall: { value: false },
-      testDate: { value: null },
       lastTested: { value: null },
       active: flat.active ?? false,
       createdAt: now,


### PR DESCRIPTION
- Updated all instances of `testDate` to `lastTested` in documentation, components, hooks, types, and models.
- Adjusted related sorting and rendering logic to reflect the new field name.
- Ensured consistency in data structures and API responses.