### PR TITLE
update dependabot.yml to target staging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       day: 'monday'
       time: '03:00' # Predictable time → fewer rebases
       timezone: 'Etc/UTC'
+    target-branch: "staging"  
     open-pull-requests-limit: 12 # Slightly higher is fine with groups
     labels:
       - 'dependencies'
@@ -84,6 +85,7 @@ updates:
       day: 'monday'
       time: '03:00'
       timezone: 'Etc/UTC'
+    target-branch: "staging"  
     labels:
       - 'dependencies'
       - 'github-actions'


### PR DESCRIPTION
Updating of the dependabot.yml file to force targeting of staging rather than main. Reason for this is to avoid potential cumulative staging/main misalignment due to dependabot PR merges directly into main bypassing staging. 