### PR TITLE
chore: trigger Vercel deployment test plus pending staging updates incluging dependabot staging fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "html-react-parser": "^6.1.3",
     "marked": "^18.0.5",
     "mongodb": "^7.3.0",
-    "next": "^16.2.9",
+    "next": "^16.2.10",
     "octokit": "^5.0.5",
     "react": "^19.2.6",
     "react-cookie": "^8.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@vercel/analytics": "^2.0.1",
     "color-interpolate": "^2.0.0",
     "gray-matter": "^4.0.3",
-    "html-react-parser": "^6.1.3",
+    "html-react-parser": "^6.1.4",
     "marked": "^18.0.5",
     "mongodb": "^7.3.0",
     "next": "^16.2.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3727,21 +3727,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-react-parser@npm:^6.1.3":
-  version: 6.1.3
-  resolution: "html-react-parser@npm:6.1.3"
+"html-react-parser@npm:^6.1.4":
+  version: 6.1.4
+  resolution: "html-react-parser@npm:6.1.4"
   dependencies:
-    domhandler: "npm:6.0.1"
-    html-dom-parser: "npm:8.0.0"
-    react-property: "npm:2.0.2"
-    style-to-js: "npm:2.0.0"
+    domhandler: 6.0.1
+    html-dom-parser: 8.0.0
+    react-property: 2.0.2
+    style-to-js: 2.0.1
   peerDependencies:
     "@types/react": 0.14 || 15 || 16 || 17 || 18 || 19
     react: 0.14 || 15 || 16 || 17 || 18 || 19
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 2b2520a6e836bb9c6b3c561f808714c7fc2393bfc093dc72cdd0b62a4d7009c9be63a685b8b967080a4cd1cd0774198b752f49133a309f5d5ba78cd390d83a6c
+  checksum: 8/b338a1fed1459ea99881ce612ce6ea41677bbfc09c3810a97f4c663c067fa0391d0376ea15d5985083f0522b7c5e4fa0d846393640937f412eac82aeddb07774
   languageName: node
   linkType: hard
 
@@ -5459,7 +5459,7 @@ __metadata:
     eslint-plugin-react: ^7.37.5
     eslint-plugin-react-hooks: ^7.1.1
     gray-matter: ^4.0.3
-    html-react-parser: ^6.1.3
+    html-react-parser: ^6.1.4
     husky: ^9.1.7
     js-yaml: ^4.2.0
     jsdom: ^29.1.1
@@ -5980,21 +5980,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"style-to-js@npm:2.0.0":
-  version: 2.0.0
-  resolution: "style-to-js@npm:2.0.0"
+"style-to-js@npm:2.0.1":
+  version: 2.0.1
+  resolution: "style-to-js@npm:2.0.1"
   dependencies:
-    style-to-object: "npm:1.0.14"
-  checksum: 6119b5f0e25d56a994de3037e52cbecfdbfebc30f7df16bce8bca0070b09f4704e13c4900e8d9554b32e66456fef192fc1f7e610f96f79a258337563169b563a
+    style-to-object: 2.0.0
+  checksum: 8/b7ce7d2752bc6cd2b7d76e0e9bab0c1430685d2bcf8af54547c19ece8f62b22dc2c8e0fac42a8094554e2bb1d9deba5d4f5e260b9fb8464138e2435c3a751b4b
   languageName: node
   linkType: hard
 
-"style-to-object@npm:1.0.14":
-  version: 1.0.14
-  resolution: "style-to-object@npm:1.0.14"
+"style-to-object@npm:2.0.0":
+  version: 2.0.0
+  resolution: "style-to-object@npm:2.0.0"
   dependencies:
-    inline-style-parser: "npm:0.2.7"
-  checksum: 854d9e9b77afc336e6d7b09348e7939f2617b34eb0895824b066d8cd1790284cb6d8b2ba36be88025b2595d715dba14b299ae76e4628a366541106f639e13679
+    inline-style-parser: 0.2.7
+  checksum: 8/b33a8a9b8ef7ab7897fa619f53f7db2b26d2b17c47120303549e23bc3e7c375d7db6f9109cb4dea87537849a21dcf5e151506bcbfd87796f611c6b15da755c61
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,10 +994,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:16.2.9":
-  version: 16.2.9
-  resolution: "@next/env@npm:16.2.9"
-  checksum: 8/11b1454b93296b3753cfb0614fbeed6a28ad0dd67e723254722bbd8ddf6c09e20890420ec1e1756433c5cef2df398a7d155cc133b3865712ec8131fadd2bec4e
+"@next/env@npm:16.2.10":
+  version: 16.2.10
+  resolution: "@next/env@npm:16.2.10"
+  checksum: 8/83efc68aed6a1dfaa96ead9e1d7273cfd50b09418e128fa4effa91bda4bd46adeaab9325fd09bae34d8046e7524a923ed9cb6975445f0820c0de399c41f9c820
   languageName: node
   linkType: hard
 
@@ -1010,58 +1010,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:16.2.9":
-  version: 16.2.9
-  resolution: "@next/swc-darwin-arm64@npm:16.2.9"
+"@next/swc-darwin-arm64@npm:16.2.10":
+  version: 16.2.10
+  resolution: "@next/swc-darwin-arm64@npm:16.2.10"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:16.2.9":
-  version: 16.2.9
-  resolution: "@next/swc-darwin-x64@npm:16.2.9"
+"@next/swc-darwin-x64@npm:16.2.10":
+  version: 16.2.10
+  resolution: "@next/swc-darwin-x64@npm:16.2.10"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:16.2.9":
-  version: 16.2.9
-  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.9"
+"@next/swc-linux-arm64-gnu@npm:16.2.10":
+  version: 16.2.10
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.10"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:16.2.9":
-  version: 16.2.9
-  resolution: "@next/swc-linux-arm64-musl@npm:16.2.9"
+"@next/swc-linux-arm64-musl@npm:16.2.10":
+  version: 16.2.10
+  resolution: "@next/swc-linux-arm64-musl@npm:16.2.10"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:16.2.9":
-  version: 16.2.9
-  resolution: "@next/swc-linux-x64-gnu@npm:16.2.9"
+"@next/swc-linux-x64-gnu@npm:16.2.10":
+  version: 16.2.10
+  resolution: "@next/swc-linux-x64-gnu@npm:16.2.10"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:16.2.9":
-  version: 16.2.9
-  resolution: "@next/swc-linux-x64-musl@npm:16.2.9"
+"@next/swc-linux-x64-musl@npm:16.2.10":
+  version: 16.2.10
+  resolution: "@next/swc-linux-x64-musl@npm:16.2.10"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:16.2.9":
-  version: 16.2.9
-  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.9"
+"@next/swc-win32-arm64-msvc@npm:16.2.10":
+  version: 16.2.10
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.10"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:16.2.9":
-  version: 16.2.9
-  resolution: "@next/swc-win32-x64-msvc@npm:16.2.9"
+"@next/swc-win32-x64-msvc@npm:16.2.10":
+  version: 16.2.10
+  resolution: "@next/swc-win32-x64-msvc@npm:16.2.10"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4721,19 +4721,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^16.2.9":
-  version: 16.2.9
-  resolution: "next@npm:16.2.9"
+"next@npm:^16.2.10":
+  version: 16.2.10
+  resolution: "next@npm:16.2.10"
   dependencies:
-    "@next/env": 16.2.9
-    "@next/swc-darwin-arm64": 16.2.9
-    "@next/swc-darwin-x64": 16.2.9
-    "@next/swc-linux-arm64-gnu": 16.2.9
-    "@next/swc-linux-arm64-musl": 16.2.9
-    "@next/swc-linux-x64-gnu": 16.2.9
-    "@next/swc-linux-x64-musl": 16.2.9
-    "@next/swc-win32-arm64-msvc": 16.2.9
-    "@next/swc-win32-x64-msvc": 16.2.9
+    "@next/env": 16.2.10
+    "@next/swc-darwin-arm64": 16.2.10
+    "@next/swc-darwin-x64": 16.2.10
+    "@next/swc-linux-arm64-gnu": 16.2.10
+    "@next/swc-linux-arm64-musl": 16.2.10
+    "@next/swc-linux-x64-gnu": 16.2.10
+    "@next/swc-linux-x64-musl": 16.2.10
+    "@next/swc-win32-arm64-msvc": 16.2.10
+    "@next/swc-win32-x64-msvc": 16.2.10
     "@swc/helpers": 0.5.15
     baseline-browser-mapping: ^2.9.19
     caniuse-lite: ^1.0.30001579
@@ -4777,7 +4777,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 8/58c819752172e27b458831e75d1e160f8b217140c4e5551ce0b9d37070629220ecaacf4344a4bfffa8981f89485051d3a2b8b3c7f8721c981e221f73e2f0ecc2
+  checksum: 8/16ac79da9ff3290cd0aa23cf1e466566feb989b6c11db474b1baae968f02ac70aff7925099b6304f68fda100126b6f2f5eaea90c1a85efa3957cdcb2191a767c
   languageName: node
   linkType: hard
 
@@ -5466,7 +5466,7 @@ __metadata:
     lint-staged: ^17.0.7
     marked: ^18.0.5
     mongodb: ^7.3.0
-    next: ^16.2.9
+    next: ^16.2.10
     octokit: ^5.0.5
     prettier: ^3.8.4
     react: ^19.2.6


### PR DESCRIPTION
Empty commit to verify Vercel deployment after GitHub integration reconnect. Also includes two pending patch dependency updates: next 16.2.10 and html-react-parser 6.1.4 plus the dependabot.yml fix into staging not main.